### PR TITLE
Fix indendation problem of pretty printer

### DIFF
--- a/Language/Haskell/TH/Compile.hs
+++ b/Language/Haskell/TH/Compile.hs
@@ -9,7 +9,7 @@ import Data.Typeable       (Typeable,
                             typeOf)
 import Language.Haskell.TH (TExp,
                             unType,
-                            pprint)
+                            pprint, Dec(ValD), Pat(VarP), mkName, Body(NormalB))
 import System.Directory    (removeFile)
 import System.FilePath     (addExtension,
                             splitExtension)
@@ -19,7 +19,7 @@ import System.IO           (hClose,
                             openTempFile)
 import Unsafe.Coerce       (unsafeCoerce)
 
-import GHC
+import GHC hiding (ValD)
 import GHC.Paths (libdir)
 import DynFlags  (defaultFatalMessager,
                   defaultFlushOut)
@@ -45,12 +45,13 @@ compile texp =
     open :: TExp a -> IO FilePath
     open e = do
         (tfile, h) <- openTempFile "." "TempMod.hs"
-        hPutStr h (unlines
-                   [ "module TempMod where"
-                   , "import GHC.Num"
-                   , ""
-                   , "myFunc :: " ++ show (typeOf (undefined :: a))
-                   , "myFunc = " ++ pprint (unType e)] )
+        hPutStr h $ unlines
+           [ "module TempMod where"
+           , "import GHC.Num"
+           , ""
+           , "myFunc :: " ++ show (typeOf (undefined :: a))
+           , pprint $ ValD (VarP (mkName "myFunc")) (NormalB (unType e)) []
+           ]
         hFlush h
         hClose h
         return tfile

--- a/Main.hs
+++ b/Main.hs
@@ -6,11 +6,9 @@ module Main where
 import Language.Haskell.TH
 import Language.Haskell.TH.Compile
 
-type TExpQ a = Q (TExp a)
-
 main :: IO ()
 main = do
-  powTExp :: (TExp (Double -> Double)) <- runQ (mkPow 23)
+  powTExp :: (TExp (Double -> Double)) <- runQ (mkPow' 23)
   putStrLn . pprint . unType $ powTExp
   pow <- compile powTExp
   print $ pow 2.0


### PR DESCRIPTION
if `pprint (unType e)` spans multiple lines, then the previous code
would fail to parse. By running the pretty printer on the whole
equation, this problem is avoided.

Else I can report that this still works with GHC-9.2!